### PR TITLE
Call Accept Only When Running Server

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -51,6 +51,7 @@
 
 #ifdef __DEMIKERNEL__
 #include <demi/libos.h>
+extern int IS_DEMIKERNEL_SERVER;
 #endif
 
 #define UNUSED(x) (void)(x)
@@ -434,6 +435,7 @@ static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len, int 
 #endif
 
 #ifdef __DEMIKERNEL__
+    IS_DEMIKERNEL_SERVER = 1;
     ret = demi_listen(s, backlog);
     if (ret != 0) {
         anetSetError(err, "listen: %s", strerror(ret));


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/redis/issues/2.

To decide whether or not we should issue a call to `demi_accept()` I introduced a global variable `IS_DEMIKERNEL_SERVER`.

This variable is set set by redis server whenever a queue descriptor is marked as a listen one (ie: a call to `demi_listen()` is issued).